### PR TITLE
Audit notebook addition/modification + Browser Extensions Report

### DIFF
--- a/Files/BrowserExtensionsCollect/Browser-Extensions-Inventory-Documentation.md
+++ b/Files/BrowserExtensionsCollect/Browser-Extensions-Inventory-Documentation.md
@@ -477,6 +477,5 @@ Write-Log "Uploaded $($UniqueExtensions.Count) unique extensions"
 ---
 
 **Document Version**: 1.0
-**Last Updated**: January 2025
-**Author**: Technical Documentation Team
-**Review Cycle**: Quarterly
+**Last Updated**: 9/16/2025
+**Author**: Petr Beloch (https://github.com/PetrBeloch)

--- a/Files/BrowserExtensionsCollect/Browser-Extensions-Inventory-Documentation.md
+++ b/Files/BrowserExtensionsCollect/Browser-Extensions-Inventory-Documentation.md
@@ -1,0 +1,482 @@
+# Browser Extensions Inventory Collection for Azure Log Analytics
+
+## Table of Contents
+1. [Overview](#overview)
+2. [Prerequisites and Requirements](#prerequisites-and-requirements)
+3. [Configuration Parameters and Setup](#configuration-parameters-and-setup)
+4. [Detailed Functionality Breakdown](#detailed-functionality-breakdown)
+5. [Data Collection Methodology](#data-collection-methodology)
+6. [Azure Log Analytics Integration](#azure-log-analytics-integration)
+7. [Security Considerations](#security-considerations)
+8. [Deployment and Usage](#deployment-and-usage)
+9. [Troubleshooting Guide](#troubleshooting-guide)
+10. [Best Practices](#best-practices)
+
+## Overview
+
+### Purpose
+The **Collect-BrowserExtentionsToLogAnalytics.ps1** script is designed to collect comprehensive browser extension inventory data from enterprise endpoints and upload it to Azure Log Analytics for security monitoring, compliance reporting, and risk assessment purposes.
+
+### Scope
+This script automatically discovers and inventories browser extensions across:
+- **Google Chrome** (all user profiles)
+- **Microsoft Edge** (all user profiles)
+- **Mozilla Firefox** (all user profiles)
+
+### Business Value
+- **Security Compliance**: Monitor potentially risky or unauthorized browser extensions
+- **Risk Assessment**: Identify shadow IT and non-approved browser add-ons
+- **Audit Requirements**: Maintain detailed inventory for compliance reporting
+- **Centralized Monitoring**: Aggregate extension data across enterprise endpoints
+
+## Prerequisites and Requirements
+
+### System Requirements
+- **Operating System**: Windows 10/11, Windows Server 2016 or later
+- **PowerShell**: Windows PowerShell 5.1 or later
+- **Network Access**: HTTPS connectivity to Azure Log Analytics (*.ods.opinsights.azure.com)
+- **Permissions**: Local administrator rights or equivalent to read user profile data
+
+### Azure Requirements
+- **Azure Subscription**: Active Azure subscription with Log Analytics workspace
+- **Log Analytics Workspace**: Configured workspace with primary key access
+- **Network Configuration**: Firewall rules allowing outbound HTTPS to Azure endpoints
+
+### Required Modules and Dependencies
+```powershell
+# No additional PowerShell modules required - uses built-in capabilities:
+# - WMI (Win32_UserProfile)
+# - System.Security.Cryptography
+# - Invoke-WebRequest
+```
+
+## Configuration Parameters and Setup
+
+### Initial Configuration
+Before executing the script, configure the following parameters at the top of the script:
+
+```powershell
+#**************************** Log Analytics Workspace Info ****************************
+$WorkspaceId = "12345678-1234-1234-1234-123456789012" # Log Analytics Workspace ID (GUID)
+$PrimaryKey = "base64encodedprimarykey==" # Log Analytics Workspace Primary Key
+$LogType = "BrowserExtensionsInventory" # Custom log name in Log Analytics
+$TimeStampField = "" # Leave blank unless you want to specify a time field
+#*************************************************************************************
+```
+
+### Parameter Details
+
+| Parameter | Type | Description | Required | Example |
+|-----------|------|-------------|----------|---------|
+| `$WorkspaceId` | GUID | Azure Log Analytics Workspace ID | Yes | `12345678-1234-1234-1234-123456789012` |
+| `$PrimaryKey` | String | Workspace primary key (base64 encoded) | Yes | `abcd1234base64key==` |
+| `$LogType` | String | Custom log table name in Log Analytics | Yes | `BrowserExtensionsInventory` |
+| `$TimeStampField` | String | Custom timestamp field (optional) | No | Leave empty for system timestamp |
+
+### Obtaining Azure Log Analytics Credentials
+
+1. **Navigate to Azure Portal**: Go to portal.azure.com
+2. **Locate Log Analytics Workspace**: Search for your workspace name
+3. **Access Workspace Settings**:
+   - Select **Settings** > **Agents management**
+   - Copy the **Workspace ID**
+   - Copy the **Primary Key**
+
+```powershell
+# Example configuration
+$WorkspaceId = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+$PrimaryKey = "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ123456789012345678901234567890abcdefghijklmnopqrstuvwxyz=="
+```
+
+## Detailed Functionality Breakdown
+
+### Core Functions
+
+#### 1. Build-Signature Function
+**Purpose**: Creates Azure Log Analytics authentication signature using HMAC-SHA256.
+
+```powershell
+Function Build-Signature ($workspaceId, $primaryKey, $date, $contentLength, $method, $contentType, $resource)
+```
+
+**Process**:
+- Constructs string to hash from HTTP method, content details, and headers
+- Generates HMAC-SHA256 hash using workspace primary key
+- Returns SharedKey authorization header for Azure authentication
+
+#### 2. Post-LogAnalyticsData Function
+**Purpose**: Uploads JSON data to Azure Log Analytics workspace.
+
+```powershell
+Function Post-LogAnalyticsData($workspaceId, $primaryKey, $body, $logType)
+```
+
+**Process**:
+- Builds authentication signature
+- Constructs Azure Log Analytics REST API request
+- Handles HTTP POST with proper headers and error handling
+- Returns HTTP status code (200 = success)
+
+#### 3. Collect-BrowserExtensions Function
+**Purpose**: Main data collection function that scans all user profiles for browser extensions.
+
+**Workflow**:
+1. Enumerates user profiles using WMI (Win32_UserProfile)
+2. Scans Chrome and Edge extension directories
+3. Parses Firefox extensions.json files
+4. Extracts extension metadata and user context
+5. Returns structured extension inventory
+
+## Data Collection Methodology
+
+### User Profile Discovery
+The script uses WMI to identify all user profiles on the system:
+
+```powershell
+$UserPaths = (Get-WmiObject win32_userprofile | Where-Object localpath -notmatch 'C:\\Windows').localpath
+```
+
+**Excluded Profiles**: System profiles under C:\Windows are automatically excluded.
+
+### Chrome and Edge Extension Collection
+
+**Extension Locations**:
+- **Chrome**: `%USERPROFILE%\AppData\Local\Google\Chrome\User Data\[Profile]\Extensions\`
+- **Edge**: `%USERPROFILE%\AppData\Local\Microsoft\Edge\User Data\[Profile]\Extensions\`
+
+**Data Extraction Process**:
+1. Scan for Default and Profile directories
+2. Enumerate extension folders by ID
+3. Read manifest.json files for metadata
+4. Handle localized extension names from messages.json files
+5. Extract version information and installation context
+
+**Localization Handling**:
+```powershell
+# Handles internationalized extension names
+if ($Manifest.name -like '__MSG*') {
+    $AppId = ($Manifest.name -replace '__MSG_', '').Trim('_')
+    # Check en_US and en locales for display names
+}
+```
+
+### Firefox Extension Collection
+
+**Extension Location**: `%USERPROFILE%\AppData\Roaming\Mozilla\Firefox\Profiles\[Profile]\extensions.json`
+
+**Data Extraction Process**:
+1. Locate Firefox profile directories
+2. Parse extensions.json configuration file
+3. Filter for active extensions (type="extension", active=true)
+4. Extract addon metadata including names, IDs, and versions
+
+### Data Structure
+
+Each extension record contains the following fields:
+
+```powershell
+[PSCustomObject]@{
+    TimeCollected = "2024-01-15 14:30:25"     # Collection timestamp
+    DeviceName    = "WORKSTATION01"           # Computer name
+    Browser       = "Google Chrome"           # Browser application
+    BrowserID     = "Profile 1"               # Browser profile identifier
+    Profile       = "Profile 1"               # User profile name
+    ExtensionName = "uBlock Origin"           # Extension display name
+    ExtensionID   = "cjpalhdlnbpafiamejdnhcphjbkeiagm" # Unique extension ID
+    Version       = "1.48.4"                 # Extension version
+    Username      = "jsmith"                  # Windows username
+}
+```
+
+## Azure Log Analytics Integration
+
+### Data Upload Process
+
+1. **Collection**: Extensions are collected from all browsers and users
+2. **Deduplication**: Removes duplicate entries based on device, profile, and extension ID
+3. **JSON Serialization**: Converts data to JSON format for Log Analytics
+4. **Authentication**: Generates HMAC-SHA256 signature for secure upload
+5. **Upload**: Posts data via REST API to Azure Log Analytics
+
+### Custom Log Table
+
+Data is stored in a custom log table with the naming convention:
+- **Table Name**: `[LogType]_CL` (e.g., `BrowserExtensionsInventory_CL`)
+- **Retention**: Follows workspace retention policy
+- **Schema**: Auto-generated based on uploaded JSON structure
+
+### Query Examples
+
+**Basic Extension Inventory**:
+```kusto
+BrowserExtensionsInventory_CL
+| summarize count() by ExtensionName_s, Browser_s
+| order by count_ desc
+```
+
+**Risk Assessment by Device**:
+```kusto
+BrowserExtensionsInventory_CL
+| where ExtensionName_s contains "Remote" or ExtensionName_s contains "VPN"
+| summarize Extensions = make_set(ExtensionName_s) by DeviceName_s, Username_s
+```
+
+**Extension Version Compliance**:
+```kusto
+BrowserExtensionsInventory_CL
+| where ExtensionName_s == "Specific Extension Name"
+| summarize Devices = count() by Version_s
+| order by Devices desc
+```
+
+## Security Considerations
+
+### Data Privacy
+- **User Context**: Script accesses user profile directories but does not read personal browser data
+- **Extension Metadata Only**: Collects only extension names, IDs, versions, and installation context
+- **No Browsing History**: Does not access or collect web browsing history or personal data
+
+### Network Security
+- **HTTPS Transport**: All data transmitted to Azure using encrypted HTTPS
+- **Authentication**: Secure HMAC-SHA256 signature-based authentication
+- **Endpoint Security**: Connections only to official Azure Log Analytics endpoints
+
+### Credential Management
+**Best Practices**:
+- Store workspace keys securely (Azure Key Vault, encrypted configuration)
+- Use least-privilege service accounts for script execution
+- Regularly rotate Log Analytics workspace keys
+- Implement credential encryption for production deployments
+
+**Example Secure Configuration**:
+```powershell
+# Production approach - retrieve from secure store
+$WorkspaceId = Get-SecureString -Name "LogAnalyticsWorkspaceId"
+$PrimaryKey = Get-SecureString -Name "LogAnalyticsPrimaryKey"
+```
+
+### Execution Security
+- **Administrator Rights**: Requires elevated permissions to read all user profiles
+- **Code Signing**: Consider signing scripts for production deployment
+- **Execution Policy**: Ensure appropriate PowerShell execution policy
+
+## Deployment and Usage
+
+### Manual Execution
+
+1. **Configure Parameters**: Update workspace ID and primary key in script
+2. **Set Execution Policy** (if required):
+   ```powershell
+   Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+   ```
+3. **Run Script**:
+   ```powershell
+   .\Collect-BrowserExtentionsToLogAnalytics.ps1
+   ```
+
+### Scheduled Deployment
+
+**Task Scheduler Configuration**:
+```powershell
+# Create scheduled task for weekly execution
+$Action = New-ScheduledTaskAction -Execute "PowerShell.exe" -Argument "-File C:\Scripts\Collect-BrowserExtentionsToLogAnalytics.ps1"
+$Trigger = New-ScheduledTaskTrigger -Weekly -DaysOfWeek Monday -At 9AM
+$Settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries
+Register-ScheduledTask -TaskName "Browser Extensions Inventory" -Action $Action -Trigger $Trigger -Settings $Settings -User "SYSTEM"
+```
+
+### Group Policy Deployment
+
+1. **Script Placement**: Deploy script to network share or local path
+2. **GPO Configuration**: Create computer startup/shutdown script policy
+3. **Security Context**: Ensure script runs with appropriate permissions
+
+### Microsoft Intune Deployment
+
+**PowerShell Script Policy**:
+1. Navigate to **Devices** > **Scripts** > **PowerShell scripts**
+2. Add new script with the following settings:
+   - **Run this script using logged on credentials**: No
+   - **Enforce script signature check**: Recommended
+   - **Run script in 64-bit PowerShell**: Yes
+
+## Troubleshooting Guide
+
+### Common Issues and Solutions
+
+#### Issue: "Access Denied" Errors
+**Symptoms**: Script fails to read user profile directories
+**Causes**:
+- Insufficient permissions
+- User profile encryption
+
+**Solutions**:
+```powershell
+# Check if running as administrator
+if (-NOT ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) {
+    Write-Warning "Script requires administrator privileges"
+    exit 1
+}
+```
+
+#### Issue: No Extensions Found
+**Symptoms**: Script reports "No browser extensions found to upload"
+**Causes**:
+- No browsers installed
+- No user profiles with extensions
+- Path resolution issues
+
+**Diagnostic Steps**:
+```powershell
+# Check browser installation paths
+$EdgePath = "${env:LOCALAPPDATA}\Microsoft\Edge\User Data"
+$ChromePath = "${env:LOCALAPPDATA}\Google\Chrome\User Data"
+$FirefoxPath = "${env:APPDATA}\Mozilla\Firefox\Profiles"
+
+Write-Output "Edge installed: $(Test-Path $EdgePath)"
+Write-Output "Chrome installed: $(Test-Path $ChromePath)"
+Write-Output "Firefox installed: $(Test-Path $FirefoxPath)"
+```
+
+#### Issue: Azure Upload Failures
+**Symptoms**: HTTP errors or "Error uploading to Log Analytics"
+**Causes**:
+- Invalid workspace credentials
+- Network connectivity issues
+- Firewall blocking
+
+**Diagnostic Commands**:
+```powershell
+# Test connectivity to Azure Log Analytics
+$TestUri = "https://$WorkspaceId.ods.opinsights.azure.com"
+Test-NetConnection -ComputerName "$WorkspaceId.ods.opinsights.azure.com" -Port 443
+
+# Verify workspace ID format (should be GUID)
+if ($WorkspaceId -match '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$') {
+    Write-Output "Workspace ID format is valid"
+} else {
+    Write-Warning "Invalid Workspace ID format"
+}
+```
+
+#### Issue: JSON Parsing Errors
+**Symptoms**: Errors reading manifest.json or extensions.json files
+**Causes**:
+- Corrupted browser files
+- Invalid JSON syntax
+- File locking issues
+
+**Mitigation**:
+```powershell
+# Add error handling for JSON parsing
+try {
+    $Manifest = Get-Content $ManifestPath -Raw | ConvertFrom-Json
+} catch {
+    Write-Warning "Failed to parse $ManifestPath : $($_.Exception.Message)"
+    continue
+}
+```
+
+### Performance Optimization
+
+**For Large Environments**:
+- Implement parallel processing for multiple user profiles
+- Add progress indicators for long-running operations
+- Consider batching uploads for systems with many extensions
+
+```powershell
+# Progress tracking example
+$UserCount = $UserPaths.Count
+$CurrentUser = 0
+foreach ($Path in $UserPaths) {
+    $CurrentUser++
+    Write-Progress -Activity "Collecting Extensions" -Status "Processing user $CurrentUser of $UserCount" -PercentComplete (($CurrentUser / $UserCount) * 100)
+    # Extension collection logic
+}
+```
+
+### Logging and Monitoring
+
+**Enhanced Logging Implementation**:
+```powershell
+# Add logging function
+function Write-Log {
+    param($Message, $Level = "INFO")
+    $Timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+    $LogEntry = "[$Timestamp] [$Level] $Message"
+    Write-Output $LogEntry
+    Add-Content -Path "C:\Logs\BrowserExtensions.log" -Value $LogEntry
+}
+
+# Usage throughout script
+Write-Log "Starting browser extension collection"
+Write-Log "Found $($AllExtensions.Count) total extensions"
+Write-Log "Uploaded $($UniqueExtensions.Count) unique extensions"
+```
+
+## Best Practices
+
+### Deployment Best Practices
+
+1. **Phased Rollout**: Deploy to pilot group before enterprise-wide deployment
+2. **Testing**: Validate in test environment with various browser configurations
+3. **Monitoring**: Implement alerting for failed uploads or collection errors
+4. **Documentation**: Maintain deployment documentation and change management
+
+### Security Best Practices
+
+1. **Credential Security**:
+   - Use Azure Key Vault for workspace credentials
+   - Implement credential rotation procedures
+   - Avoid hardcoding sensitive values
+
+2. **Access Control**:
+   - Limit script access to authorized administrators
+   - Use dedicated service accounts with minimal permissions
+   - Implement code signing for script integrity
+
+3. **Network Security**:
+   - Whitelist Azure Log Analytics endpoints in firewalls
+   - Use corporate proxy configurations where required
+   - Monitor network traffic for anomalies
+
+### Operational Best Practices
+
+1. **Scheduling**:
+   - Run during low-impact hours (evenings/weekends)
+   - Implement randomized execution to avoid thundering herd
+   - Consider user logon triggers for real-time collection
+
+2. **Data Management**:
+   - Establish data retention policies in Log Analytics
+   - Implement data archival for compliance requirements
+   - Regular cleanup of obsolete extension records
+
+3. **Monitoring and Alerting**:
+   - Set up alerts for collection failures
+   - Monitor extension trends and anomalies
+   - Create dashboards for security team visibility
+
+### Performance Best Practices
+
+1. **Resource Management**:
+   - Limit concurrent operations on systems with many users
+   - Implement timeout handling for slow file operations
+   - Monitor CPU and memory usage during execution
+
+2. **Error Handling**:
+   - Implement comprehensive try-catch blocks
+   - Log errors with sufficient detail for troubleshooting
+   - Continue processing on non-critical errors
+
+3. **Optimization**:
+   - Cache frequently accessed data
+   - Use efficient PowerShell cmdlets and operators
+   - Consider PowerShell Jobs for parallel processing
+
+---
+
+**Document Version**: 1.0
+**Last Updated**: January 2025
+**Author**: Technical Documentation Team
+**Review Cycle**: Quarterly

--- a/Files/BrowserExtensionsCollect/Collect-BrowserExtentionsToLogAnalytics.ps1
+++ b/Files/BrowserExtensionsCollect/Collect-BrowserExtentionsToLogAnalytics.ps1
@@ -1,0 +1,175 @@
+#**************************** Log Analytics Workspace Info ****************************
+$WorkspaceId = "" # Log Analytics Workspace ID (GUID)
+$PrimaryKey = "" # Log Analytics Workspace Primary Key
+$LogType = "DevicesBrowserExtensionsInventory" # Custom log name in Log Analytics
+$TimeStampField = "" # Leave blank unless you want to specify a time field
+#*************************************************************************************
+
+Function Build-Signature ($workspaceId, $primaryKey, $date, $contentLength, $method, $contentType, $resource) {
+    $xHeaders = "x-ms-date:" + $date
+    $stringToHash = $method + "`n" + $contentLength + "`n" + $contentType + "`n" + $xHeaders + "`n" + $resource
+    $bytesToHash = [Text.Encoding]::UTF8.GetBytes($stringToHash)
+    $keyBytes = [Convert]::FromBase64String($primaryKey)
+    $sha256 = New-Object System.Security.Cryptography.HMACSHA256
+    $sha256.Key = $keyBytes
+    $calculatedHash = $sha256.ComputeHash($bytesToHash)
+    $encodedHash = [Convert]::ToBase64String($calculatedHash)
+    $authorization = 'SharedKey {0}:{1}' -f $workspaceId,$encodedHash
+    return $authorization
+}
+
+Function Post-LogAnalyticsData($workspaceId, $primaryKey, $body, $logType) {
+    $method = "POST"
+    $contentType = "application/json"
+    $resource = "/api/logs"
+    $rfc1123date = [DateTime]::UtcNow.ToString("r")
+    $contentLength = $body.Length
+    $signature = Build-Signature `
+        -workspaceId $workspaceId `
+        -primaryKey $primaryKey `
+        -date $rfc1123date `
+        -contentLength $contentLength `
+        -method $method `
+        -contentType $contentType `
+        -resource $resource
+    $uri = "https://" + $workspaceId + ".ods.opinsights.azure.com" + $resource + "?api-version=2016-04-01"
+    $headers = @{
+        "Authorization" = $signature;
+        "Log-Type" = $logType;
+        "x-ms-date" = $rfc1123date;
+        "time-generated-field" = $TimeStampField;
+    }
+    try {
+        $response = Invoke-WebRequest -Uri $uri -Method $method -ContentType $contentType -Headers $headers -Body $body -UseBasicParsing
+        return $response.StatusCode
+    } catch {
+        Write-Output "Error uploading to Log Analytics: $_"
+        return 0
+    }
+}
+
+function Collect-BrowserExtensions {
+    $Extensions = @()
+    $UserPaths = (Get-WmiObject win32_userprofile | Where-Object localpath -notmatch 'C:\\Windows').localpath
+    foreach ($Path in $UserPaths) {
+        # Edge and Chrome
+        $MSEdgeDir = $Path + '\AppData\Local\Microsoft\Edge\User Data'
+        $GoogDir = $Path + '\AppData\Local\Google\Chrome\User Data'
+        $CheckBrowserDir = New-Object Collections.Generic.List[string]
+        if (Test-Path $MSEdgeDir) { $CheckBrowserDir.Add($MSEdgeDir) }
+        if (Test-Path $GoogDir) { $CheckBrowserDir.Add($GoogDir) }
+        foreach ($BrowserDir in $CheckBrowserDir) {
+            $ProfilePaths = (Get-ChildItem -Path $BrowserDir | Where-Object Name -match 'Default|Profile').FullName
+            foreach ($ProfilePath in $ProfilePaths) {
+                $ExtPath = $ProfilePath + '\Extensions'
+                if (Test-Path $ExtPath) {
+                    $BrowserProfileName = ($ProfilePath | Split-Path -Leaf)
+                    $Application = ($ProfilePath | Split-Path -Parent | Split-Path -Parent | Split-Path -Leaf)
+                    $Username = ($ProfilePath | Split-Path -Parent | Split-Path -Parent | Split-Path -Parent | Split-Path -Parent | Split-Path -Parent | Split-Path -Parent | Split-Path -Leaf)
+                    $ExtFolders = Get-Childitem $ExtPath | Where-Object Name -ne 'Temp'
+                    foreach ($Folder in $ExtFolders) {
+                        $VerFolders = Get-Childitem $Folder.FullName
+                        foreach ($Version in $VerFolders) {
+                            if (Test-Path -Path ($Version.FullName + '\manifest.json')) {
+                                $Manifest = Get-Content ($Version.FullName + '\manifest.json') -Encoding UTF8 | ConvertFrom-Json
+                                $ExtName = $null # <-- Always reset for each extension
+                                if ($Manifest.name -like '__MSG*') {
+                                    $AppId = ($Manifest.name -replace '__MSG_', '').Trim('_')
+                                    @('\_locales\en_US\', '\_locales\en\') | ForEach-Object {
+                                        if (Test-Path -Path ($Version.Fullname + $_ + 'messages.json')) {
+                                            $AppManifest = Get-Content ($Version.Fullname + $_ + 'messages.json') -Encoding UTF8 | ConvertFrom-Json
+                                            @($AppManifest.appName.message, $AppManifest.extName.message,
+                                                $AppManifest.extensionName.message, $AppManifest.app_name.message,
+                                                $AppManifest.application_title.message, $AppManifest.$AppId.message) |
+                                            ForEach-Object {
+                                                if (($_) -and (-not($ExtName))) {
+                                                    $ExtName = $_
+                                                }
+                                            }
+                                        }
+                                    }
+                                } else {
+                                    $ExtName = $Manifest.name
+                                }
+                                if (-not $ExtName -or $ExtName -eq "") {
+                                    $ExtName = $Folder.Name
+                                }
+                                $Extensions += [PSCustomObject]@{
+                                    TimeCollected = (Get-Date -Format "yyyy-MM-dd HH:mm:ss")
+                                    DeviceName    = $env:COMPUTERNAME
+                                    Browser       = $Application
+                                    BrowserID     = $BrowserProfileName
+                                    Profile       = $BrowserProfileName
+                                    ExtensionName = $ExtName
+                                    ExtensionID   = $Folder.Name
+                                    Version       = $Manifest.version
+                                    Username      = $Username
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        # Firefox
+        $FirefoxProfilesDir = $Path + '\AppData\Roaming\Mozilla\Firefox\Profiles'
+        if (Test-Path $FirefoxProfilesDir) {
+            $FirefoxProfiles = Get-ChildItem -Path $FirefoxProfilesDir -Directory
+            foreach ($FirefoxProfile in $FirefoxProfiles) {
+                $ExtensionsJson = Join-Path $FirefoxProfile.FullName 'extensions.json'
+                if (Test-Path $ExtensionsJson) {
+                    try {
+                        $ExtensionsData = Get-Content $ExtensionsJson -Raw -Encoding UTF8 | ConvertFrom-Json
+                        foreach ($Addon in $ExtensionsData.addons) {
+                            if ($Addon.type -eq "extension" -and $Addon.active -eq $true) {
+                                $ExtName = $Addon.defaultLocale.name
+                                if (-not $ExtName -or $ExtName -eq "") {
+                                    $ExtName = $Addon.id
+                                }
+                                $Extensions += [PSCustomObject]@{
+                                    TimeCollected = (Get-Date -Format "yyyy-MM-dd HH:mm:ss")
+                                    DeviceName    = $env:COMPUTERNAME
+                                    Browser       = "Mozilla Firefox"
+                                    BrowserID     = $FirefoxProfile.Name
+                                    Profile       = $FirefoxProfile.Name
+                                    ExtensionName = $ExtName
+                                    ExtensionID   = $Addon.id
+                                    Version       = $Addon.version
+                                    Username      = ($Path | Split-Path -Leaf)
+                                }
+                            }
+                        }
+                    } catch {
+                        Write-Output "Error reading $ExtensionsJson"
+                    }
+                }
+            }
+        }
+    }
+    return $Extensions
+}
+
+# Collect all extensions
+$AllExtensions = Collect-BrowserExtensions
+
+# Deduplicate
+$UniqueExtensions = $AllExtensions | Sort-Object DeviceName,Profile,ExtensionID,ExtensionName -Unique
+
+# Convert to JSON for Log Analytics
+$ExtensionsJson = $UniqueExtensions | ConvertTo-Json
+
+# Only send data if there are extensions found
+if ($ExtensionsJson -and $ExtensionsJson -ne "[]") {
+    $params = @{
+        WorkspaceId = $WorkspaceId
+        PrimaryKey  = $PrimaryKey
+        Body        = ([System.Text.Encoding]::UTF8.GetBytes($ExtensionsJson))
+        LogType     = $LogType
+    }
+    $LogResponse = Post-LogAnalyticsData @params
+    Write-Output "Uploaded $($UniqueExtensions.Count) browser extensions to Azure Log Analytics. Status: $LogResponse"
+    exit 0
+} else {
+    Write-Output "No browser extensions found to upload."
+    exit 1
+}

--- a/Intune Monitoring v0.2.workbook
+++ b/Intune Monitoring v0.2.workbook
@@ -150,6 +150,14 @@
             "linkLabel": "Audit",
             "subTarget": "Audit",
             "style": "link"
+          },
+          {
+            "id": "7f8d5e9a-3c2b-4a1f-9d8e-6f5a4b3c2d1e",
+            "cellValue": "tab",
+            "linkTarget": "parameter",
+            "linkLabel": "Browser Extensions",
+            "subTarget": "BrowserExtensions",
+            "style": "link"
           }
         ]
       },
@@ -9105,9 +9113,9 @@
           {
             "type": 1,
             "content": {
-              "json": "Coming Soon - Check the development of IntuneMonitoring on [GitHub](https://github.com/ugurkocde/IntuneMonitoring) or on [LinkedIn](https://www.linkedin.com/newsletters/just-shipped-by-ugur-7345954317935276033/)"
+              "json": "### 📊 User Enrollment & Deployment \n\n🌐 **Visit [IntuneMonitoring.com](https://intunemonitoring.com) for updates and to customize your dashboard**"
             },
-            "name": "text - 0"
+            "name": "placeholder"
           }
         ]
       },
@@ -9128,9 +9136,9 @@
           {
             "type": 1,
             "content": {
-              "json": "Coming Soon - Check the development of IntuneMonitoring on [GitHub](https://github.com/ugurkocde/IntuneMonitoring) or on [LinkedIn](https://www.linkedin.com/newsletters/just-shipped-by-ugur-7345954317935276033/)"
+              "json": "### 📊 Policies \n\n🌐 **Visit [IntuneMonitoring.com](https://intunemonitoring.com) for updates and to customize your dashboard**"
             },
-            "name": "text - 0"
+            "name": "placeholder"
           }
         ]
       },
@@ -9146,14 +9154,902 @@
       "content": {
         "version": "NotebookGroup/1.0",
         "groupType": "editable",
-        "title": "Audit",
+        "title": "Intune Audit Monitoring",
         "items": [
           {
             "type": 1,
             "content": {
-              "json": "Coming Soon - Check the development of IntuneMonitoring on [GitHub](https://github.com/ugurkocde/IntuneMonitoring) or on [LinkedIn](https://www.linkedin.com/newsletters/just-shipped-by-ugur-7345954317935276033/)"
+              "json": "### 🔍 Intune Audit & Security Monitoring\n\n**Comprehensive audit trail analysis for Microsoft Intune operations with risk-based monitoring and alerting.**\n\n#### 📊 Coverage Areas:\n- **🔐 Security Operations**: Certificate management, privileged actions, anomaly detection\n- **📱 Application Management**: App assignments, deployments, policy changes\n- **🛡️ Compliance Monitoring**: User access patterns, administrative activities\n- **⚠️ Real-time Alerting**: Suspicious activities, bulk operations, security violations\n\n---"
             },
-            "name": "text - 0"
+            "name": "AuditIntro"
+          },
+          {
+            "type": 11,
+            "content": {
+              "version": "LinkItem/1.0",
+              "style": "tabs",
+              "links": [
+                {
+                  "id": "audit-executive",
+                  "cellValue": "auditTab",
+                  "linkTarget": "parameter",
+                  "linkLabel": "📈 Executive",
+                  "subTarget": "Executive",
+                  "style": "link"
+                },
+                {
+                  "id": "audit-security",
+                  "cellValue": "auditTab",
+                  "linkTarget": "parameter",
+                  "linkLabel": "🔐 Security",
+                  "subTarget": "Security",
+                  "style": "link"
+                },
+                {
+                  "id": "audit-operations",
+                  "cellValue": "auditTab",
+                  "linkTarget": "parameter",
+                  "linkLabel": "⚙️ Operations",
+                  "subTarget": "Operations",
+                  "style": "link"
+                },
+                {
+                  "id": "audit-compliance",
+                  "cellValue": "auditTab",
+                  "linkTarget": "parameter",
+                  "linkLabel": "📋 Compliance",
+                  "subTarget": "Compliance",
+                  "style": "link"
+                },
+                {
+                  "id": "audit-alerts",
+                  "cellValue": "auditTab",
+                  "linkTarget": "parameter",
+                  "linkLabel": "🚨 Alerts",
+                  "subTarget": "Alerts",
+                  "style": "link"
+                }
+              ]
+            },
+            "name": "AuditTabs"
+          },
+          {
+            "type": 9,
+            "content": {
+              "version": "KqlParameterItem/1.0",
+              "parameters": [
+                {
+                  "id": "audit-timerange",
+                  "version": "KqlParameterItem/1.0",
+                  "name": "AuditTimeRange",
+                  "label": "Time Range",
+                  "type": 4,
+                  "description": "Select time range for audit analysis",
+                  "value": {
+                    "durationMs": 172800000
+                  },
+                  "typeSettings": {
+                    "selectableValues": [
+                      {
+                        "durationMs": 1800000
+                      },
+                      {
+                        "durationMs": 3600000
+                      },
+                      {
+                        "durationMs": 14400000
+                      },
+                      {
+                        "durationMs": 43200000
+                      },
+                      {
+                        "durationMs": 86400000
+                      },
+                      {
+                        "durationMs": 172800000
+                      },
+                      {
+                        "durationMs": 259200000
+                      },
+                      {
+                        "durationMs": 604800000
+                      },
+                      {
+                        "durationMs": 1209600000
+                      },
+                      {
+                        "durationMs": 2592000000
+                      },
+                      {
+                        "durationMs": 5184000000
+                      },
+                      {
+                        "durationMs": 7776000000
+                      }
+                    ],
+                    "allowCustom": true
+                  }
+                },
+                {
+                  "id": "audit-actor-filter",
+                  "version": "KqlParameterItem/1.0",
+                  "name": "ActorFilter",
+                  "label": "Actor (User)",
+                  "type": 2,
+                  "description": "Filter by specific user/actor",
+                  "multiSelect": true,
+                  "quote": "'",
+                  "delimiter": ",",
+                  "query": "IntuneAuditLogs\n| where TimeGenerated {AuditTimeRange}\n| extend ActorUPN = tostring(parse_json(Properties).Actor.UPN)\n| where isnotempty(ActorUPN)\n| where OperationName !contains \"Create ClientCertificate\"\n| summarize Count = count() by ActorUPN\n| order by Count desc\n| project Value = ActorUPN, Label = strcat(ActorUPN, ' (', Count, ' operations)')\n| limit 50",
+                  "value": [
+                    "value::all"
+                  ],
+                  "typeSettings": {
+                    "additionalResourceOptions": [
+                      "value::all"
+                    ],
+                    "selectAllValue": "*",
+                    "showDefault": false
+                  },
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces"
+                }
+              ],
+              "style": "pills",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces"
+            },
+            "name": "AuditParameters"
+          },
+          {
+            "type": 12,
+            "content": {
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
+              "title": "Executive Dashboard",
+              "items": [
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "IntuneAuditLogs\n| where TimeGenerated {AuditTimeRange}\n| extend ActorUPN = tostring(parse_json(Properties).Actor.UPN)\n| where '*' in ({ActorFilter}) or ActorUPN in ({ActorFilter})\n| extend Category = tostring(Category), ActivityType = toint(parse_json(Properties).ActivityType)\n| where OperationName !contains \"Create ClientCertificate\"\n| extend \n    RiskLevel = case(\n        OperationName contains \"Delete\", \"High\",\n        OperationName contains \"Create\", \"Medium\",\n        OperationName contains \"Patch\", \"Low\",\n        \"Low\"\n    ),\n    OperationType = case(\n        ActivityType == 0, \"Create\",\n        ActivityType == 1, \"Delete\",\n        ActivityType == 2, \"Update\",\n        ActivityType == 3, \"Assign\",\n        \"Other\"\n    )\n| summarize \n    TotalOperations = count(),\n    UniqueActors = dcount(ActorUPN),\n    CriticalOps = countif(RiskLevel == \"Critical\"),\n    HighRiskOps = countif(RiskLevel == \"High\")\n| extend RiskScore = (CriticalOps * 4 + HighRiskOps * 2) * 100 / TotalOperations",
+                    "size": 4,
+                    "title": "Executive KPIs",
+                    "queryType": 0,
+                    "resourceType": "microsoft.operationalinsights/workspaces",
+                    "visualization": "tiles",
+                    "tileSettings": {
+                      "titleContent": {
+                        "columnMatch": "TotalOperations",
+                        "formatter": 1,
+                        "formatOptions": {
+                          "customDisplayName": "Total Operations"
+                        }
+                      },
+                      "leftContent": {
+                        "columnMatch": "TotalOperations",
+                        "formatter": 12,
+                        "formatOptions": {
+                          "palette": "blue"
+                        }
+                      },
+                      "secondaryContent": {
+                        "columnMatch": "UniqueActors",
+                        "formatter": 1,
+                        "formatOptions": {
+                          "customDisplayName": "Active Administrators"
+                        }
+                      },
+                      "showBorder": false
+                    }
+                  },
+                  "customWidth": "25",
+                  "name": "ExecutiveKPI1"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "IntuneAuditLogs\n| where TimeGenerated {AuditTimeRange}\n| extend ActorUPN = tostring(parse_json(Properties).Actor.UPN)\n| where '*' in ({ActorFilter}) or ActorUPN in ({ActorFilter})\n| where OperationName !contains \"Create ClientCertificate\"\n| extend \n    RiskLevel = case(\n        OperationName contains \"Delete\", \"High\",\n        OperationName contains \"Create\", \"Medium\",\n        OperationName contains \"Patch\", \"Low\",\n        \"Low\"\n    )\n| summarize \n    TotalOperations = count(),\n    HighRiskOps = countif(RiskLevel == \"High\")\n| extend RiskScore = (HighRiskOps * 2) * 100 / TotalOperations\n| project RiskScore",
+                    "size": 4,
+                    "title": "Security Risk Score",
+                    "queryType": 0,
+                    "resourceType": "microsoft.operationalinsights/workspaces",
+                    "visualization": "tiles",
+                    "tileSettings": {
+                      "titleContent": {
+                        "columnMatch": "RiskScore",
+                        "formatter": 1,
+                        "formatOptions": {
+                          "customDisplayName": "Risk Score"
+                        }
+                      },
+                      "leftContent": {
+                        "columnMatch": "RiskScore",
+                        "formatter": 12,
+                        "formatOptions": {
+                          "palette": "redBright",
+                          "thresholdsOptions": "colors",
+                          "thresholdsGrid": [
+                            {
+                              "operator": "<",
+                              "thresholdValue": "25",
+                              "representation": "green"
+                            },
+                            {
+                              "operator": "<",
+                              "thresholdValue": "50",
+                              "representation": "yellow"
+                            },
+                            {
+                              "operator": ">=",
+                              "thresholdValue": "50",
+                              "representation": "redBright"
+                            }
+                          ]
+                        },
+                        "numberFormat": {
+                          "unit": 1,
+                          "options": {
+                            "style": "decimal",
+                            "maximumFractionDigits": 1
+                          }
+                        }
+                      },
+                      "showBorder": false
+                    }
+                  },
+                  "customWidth": "25",
+                  "name": "RiskScore"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "IntuneAuditLogs\n| where TimeGenerated {AuditTimeRange}\n| extend ActorUPN = tostring(parse_json(Properties).Actor.UPN)\n| where '*' in ({ActorFilter}) or ActorUPN in ({ActorFilter})\n| where OperationName !contains \"Create ClientCertificate\"\n| extend ActivityType = toint(parse_json(Properties).ActivityType)\n| extend \n    OperationType = case(\n        ActivityType == 0, \"Create\",\n        ActivityType == 1, \"Delete\",\n        ActivityType == 2, \"Update\",\n        ActivityType == 3, \"Assign\",\n        \"Other\"\n    )\n| summarize Count = count() by TimeGenerated = bin(TimeGenerated, 1h), OperationType\n| render timechart",
+                    "size": 0,
+                    "title": "Operations Trend (Hourly)",
+                    "queryType": 0,
+                    "resourceType": "microsoft.operationalinsights/workspaces",
+                    "visualization": "areachart"
+                  },
+                  "customWidth": "50",
+                  "name": "OperationsTrend"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "IntuneAuditLogs\n| where TimeGenerated {AuditTimeRange}\n| extend ActorUPN = tostring(parse_json(Properties).Actor.UPN)\n| where '*' in ({ActorFilter}) or ActorUPN in ({ActorFilter})\n| where OperationName !contains \"Create ClientCertificate\"\n| extend \n    RiskLevel = case(\n        OperationName contains \"Delete\", \"High\",\n        OperationName contains \"Create\", \"Medium\",\n        OperationName contains \"Patch\", \"Low\",\n        \"Low\"\n    )\n| summarize Count = count() by RiskLevel\n| extend Percentage = Count * 100.0 / toscalar(\n    IntuneAuditLogs\n    | where TimeGenerated {AuditTimeRange}\n    | extend ActorUPN = tostring(parse_json(Properties).Actor.UPN)\n    | where '*' in ({ActorFilter}) or ActorUPN in ({ActorFilter})\n    | where OperationName !contains \"Create ClientCertificate\"\n    | count\n)\n| project RiskLevel, Count, Percentage\n| order by \n    case(\n        RiskLevel == \"High\", 1,\n        RiskLevel == \"Medium\", 2,\n        RiskLevel == \"Low\", 3,\n        4\n    )",
+                    "size": 0,
+                    "title": "Risk Distribution",
+                    "queryType": 0,
+                    "resourceType": "microsoft.operationalinsights/workspaces",
+                    "visualization": "piechart"
+                  },
+                  "customWidth": "50",
+                  "name": "RiskDistribution"
+                }
+              ]
+            },
+            "conditionalVisibility": {
+              "parameterName": "auditTab",
+              "comparison": "isEqualTo",
+              "value": "Executive"
+            },
+            "name": "ExecutiveDashboard"
+          },
+          {
+            "type": 12,
+            "content": {
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
+              "title": "Security Operations Center",
+              "items": [
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "IntuneAuditLogs\n| where TimeGenerated {AuditTimeRange}\n| extend ActorUPN = tostring(parse_json(Properties).Actor.UPN)\n| where '*' in ({ActorFilter}) or ActorUPN in ({ActorFilter})\n| where OperationName !contains \"Create ClientCertificate\"\n| extend HourOfDay = hourofday(TimeGenerated)\n| where HourOfDay < 6 or HourOfDay > 20  // Outside business hours (6 AM - 8 PM)\n| extend \n    RiskLevel = case(\n        OperationName contains \"Delete\", \"High\",\n        OperationName contains \"Create\", \"Medium\",\n        \"Low\"\n    )\n| project \n    TimeGenerated,\n    ActorUPN,\n    OperationName,\n    RiskLevel,\n    HourOfDay,\n    ResultType\n| order by TimeGenerated desc",
+                    "size": 0,
+                    "title": "⏰ Off-Hours Activity",
+                    "queryType": 0,
+                    "resourceType": "microsoft.operationalinsights/workspaces",
+                    "visualization": "table",
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "RiskLevel",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "colors",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Critical",
+                                "representation": "redBright"
+                              },
+                              {
+                                "operator": "==",
+                                "thresholdValue": "High",
+                                "representation": "orange"
+                              },
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Medium",
+                                "representation": "yellow"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "representation": "green"
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "customWidth": "100",
+                  "name": "OffHoursActivity"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "IntuneAuditLogs\n| where TimeGenerated {AuditTimeRange}\n| extend ActorUPN = tostring(parse_json(Properties).Actor.UPN)\n| where '*' in ({ActorFilter}) or ActorUPN in ({ActorFilter})\n| where OperationName !contains \"Create ClientCertificate\"\n| extend TargetCount = array_length(parse_json(Properties).TargetObjectIds)\n| where TargetCount >= 5  // Bulk operations (5+ targets)\n| project \n    TimeGenerated,\n    ActorUPN,\n    OperationName,\n    TargetCount,\n    CorrelationId,\n    ResultType\n| order by TargetCount desc, TimeGenerated desc",
+                    "size": 0,
+                    "title": "📦 Bulk Operations (5+ Targets)",
+                    "queryType": 0,
+                    "resourceType": "microsoft.operationalinsights/workspaces",
+                    "visualization": "table",
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "TargetCount",
+                          "formatter": 8,
+                          "formatOptions": {
+                            "palette": "redBright"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "customWidth": "100",
+                  "name": "BulkOperations"
+                }
+              ]
+            },
+            "conditionalVisibility": {
+              "parameterName": "auditTab",
+              "comparison": "isEqualTo",
+              "value": "Security"
+            },
+            "name": "SecurityOperations"
+          },
+          {
+            "type": 12,
+            "content": {
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
+              "items": [
+                {
+                  "type": 1,
+                  "content": {
+                    "json": "### ⚙️ Operations Overview\n\nMonitor administrative operations that impact your Intune environment including policy changes, application management, and configuration updates."
+                  },
+                  "name": "OperationsIntro"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "IntuneAuditLogs\n| where TimeGenerated {AuditTimeRange}\n| extend ActorUPN = tostring(parse_json(Properties).Actor.UPN)\n| where '*' in ({ActorFilter}) or ActorUPN in ({ActorFilter})\n| where OperationName !contains \"Create ClientCertificate\"\n| where OperationName contains \"Policy\" or OperationName contains \"Configuration\" or OperationName contains \"Profile\"\n| extend \n    ChangeType = case(\n        OperationName contains \"Create\", \"Created\",\n        OperationName contains \"Delete\", \"Deleted\",\n        OperationName contains \"Patch\" or OperationName contains \"Update\", \"Modified\",\n        \"Other\"\n    ),\n    PolicyType = case(\n        OperationName contains \"DeviceConfiguration\", \"Device Configuration\",\n        OperationName contains \"DeviceCompliancePolicy\", \"Compliance Policy\",\n        OperationName contains \"DeviceManagementConfigurationPolicy\", \"Settings Catalog\",\n        OperationName contains \"WindowsAutopilotDeploymentProfile\", \"Autopilot Profile\",\n        OperationName contains \"DeviceEnrollmentConfiguration\", \"Enrollment Configuration\",\n        \"Other Policy\"\n    )\n| summarize OperationCount = count() by PolicyType, ChangeType, TimeGenerated = bin(TimeGenerated, 1h)\n| order by TimeGenerated desc, OperationCount desc",
+                    "size": 0,
+                    "title": "📋 Policy Changes Over Time",
+                    "queryType": 0,
+                    "resourceType": "microsoft.operationalinsights/workspaces",
+                    "visualization": "areachart",
+                    "chartSettings": {
+                      "xAxis": "TimeGenerated",
+                      "yAxis": [
+                        "OperationCount"
+                      ],
+                      "group": "PolicyType",
+                      "xSettings": {
+                        "numberFormatSettings": {
+                          "unit": 17,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "customWidth": "50",
+                  "name": "PolicyChangesChart"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "IntuneAuditLogs\n| where TimeGenerated {AuditTimeRange}\n| extend ActorUPN = tostring(parse_json(Properties).Actor.UPN)\n| where '*' in ({ActorFilter}) or ActorUPN in ({ActorFilter})\n| where OperationName !contains \"Create ClientCertificate\"\n| where OperationName contains \"MobileApp\" or OperationName contains \"Application\"\n| extend \n    AppOperation = case(\n        OperationName contains \"Create\", \"App Created\",\n        OperationName contains \"Delete\", \"App Deleted\",\n        OperationName contains \"Patch\", \"App Modified\",\n        OperationName contains \"Assignment\", \"Assignment Changed\",\n        \"Other\"\n    )\n| summarize Count = count() by AppOperation, TimeGenerated = bin(TimeGenerated, 1d)\n| order by TimeGenerated desc",
+                    "size": 0,
+                    "title": "📱 Application Management Activities",
+                    "queryType": 0,
+                    "resourceType": "microsoft.operationalinsights/workspaces",
+                    "visualization": "columnchart",
+                    "chartSettings": {
+                      "xAxis": "TimeGenerated",
+                      "yAxis": [
+                        "Count"
+                      ],
+                      "group": "AppOperation"
+                    }
+                  },
+                  "customWidth": "50",
+                  "name": "AppManagementChart"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "IntuneAuditLogs\n| where TimeGenerated {AuditTimeRange}\n| extend ActorUPN = tostring(parse_json(Properties).Actor.UPN)\n| where '*' in ({ActorFilter}) or ActorUPN in ({ActorFilter})\n| where OperationName !contains \"Create ClientCertificate\"\n| where OperationName contains \"Policy\" or OperationName contains \"Configuration\" or OperationName contains \"Profile\"\n| extend \n    TargetResource = tostring(parse_json(Properties).TargetDisplayNames[0]),\n    ChangeType = case(\n        OperationName contains \"Create\", \"✅ Created\",\n        OperationName contains \"Delete\", \"❌ Deleted\", \n        OperationName contains \"Patch\", \"📝 Modified\",\n        \"🔄 Other\"\n    ),\n    PolicyCategory = case(\n        OperationName contains \"DeviceConfiguration\", \"Device Configuration\",\n        OperationName contains \"DeviceCompliancePolicy\", \"Compliance Policy\",\n        OperationName contains \"DeviceManagementConfigurationPolicy\", \"Settings Catalog\",\n        OperationName contains \"WindowsAutopilotDeploymentProfile\", \"Autopilot Profile\",\n        \"Other Policy Type\"\n    )\n| project \n    TimeGenerated,\n    ActorUPN,\n    PolicyCategory,\n    ChangeType,\n    TargetResource,\n    OperationName,\n    ResultType\n| order by TimeGenerated desc\n| take 100",
+                    "size": 0,
+                    "title": "📋 Recent Policy Changes (Last 100)",
+                    "queryType": 0,
+                    "resourceType": "microsoft.operationalinsights/workspaces",
+                    "visualization": "table",
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "ChangeType",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "icons",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "contains",
+                                "thresholdValue": "Created",
+                                "representation": "success",
+                                "text": "✅"
+                              },
+                              {
+                                "operator": "contains",
+                                "thresholdValue": "Deleted",
+                                "representation": "critical",
+                                "text": "❌"
+                              },
+                              {
+                                "operator": "contains",
+                                "thresholdValue": "Modified",
+                                "representation": "warning",
+                                "text": "📝"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "ResultType",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "colors",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Success",
+                                "representation": "green"
+                              },
+                              {
+                                "operator": "!=",
+                                "thresholdValue": "Success",
+                                "representation": "redBright"
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "customWidth": "100",
+                  "name": "PolicyChangesTable"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "IntuneAuditLogs\n| where TimeGenerated {AuditTimeRange}\n| extend ActorUPN = tostring(parse_json(Properties).Actor.UPN)\n| where '*' in ({ActorFilter}) or ActorUPN in ({ActorFilter})\n| where OperationName !contains \"Create ClientCertificate\"\n| where OperationName contains \"MobileApp\" or OperationName contains \"Application\"\n| extend \n    AppName = tostring(parse_json(Properties).TargetDisplayNames[0]),\n    AppAction = case(\n        OperationName contains \"Create\", \"🆕 Created\",\n        OperationName contains \"Delete\", \"🗑️ Deleted\",\n        OperationName contains \"Patch\", \"✏️ Modified\",\n        OperationName contains \"Assignment\", \"🎯 Assignment Changed\",\n        \"🔄 Other\"\n    )\n| project \n    TimeGenerated,\n    ActorUPN,\n    AppAction,\n    AppName,\n    OperationName,\n    ResultType\n| order by TimeGenerated desc\n| take 50",
+                    "size": 0,
+                    "title": "📱 Recent Application Operations (Last 50)",
+                    "queryType": 0,
+                    "resourceType": "microsoft.operationalinsights/workspaces",
+                    "visualization": "table",
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "AppAction",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "icons",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "contains",
+                                "thresholdValue": "Created",
+                                "representation": "success",
+                                "text": "🆕"
+                              },
+                              {
+                                "operator": "contains",
+                                "thresholdValue": "Deleted",
+                                "representation": "critical",
+                                "text": "🗑️"
+                              },
+                              {
+                                "operator": "contains",
+                                "thresholdValue": "Modified",
+                                "representation": "warning",
+                                "text": "✏️"
+                              },
+                              {
+                                "operator": "contains",
+                                "thresholdValue": "Assignment",
+                                "representation": "info",
+                                "text": "🎯"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "ResultType",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "colors",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Success",
+                                "representation": "green"
+                              },
+                              {
+                                "operator": "!=",
+                                "thresholdValue": "Success",
+                                "representation": "redBright"
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "customWidth": "100",
+                  "name": "ApplicationOperationsTable"
+                }
+              ]
+            },
+            "conditionalVisibility": {
+              "parameterName": "auditTab",
+              "comparison": "isEqualTo",
+              "value": "Operations"
+            },
+            "name": "OperationsTab"
+          },
+          {
+            "type": 12,
+            "content": {
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
+              "items": [
+                {
+                  "type": 1,
+                  "content": {
+                    "json": "### 📋 Compliance Monitoring\n\nTrack device compliance operations, policy assignments, and enforcement actions across your Intune environment."
+                  },
+                  "name": "ComplianceIntro"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "IntuneAuditLogs\n| where TimeGenerated {AuditTimeRange}\n| extend ActorUPN = tostring(parse_json(Properties).Actor.UPN)\n| where '*' in ({ActorFilter}) or ActorUPN in ({ActorFilter})\n| where OperationName !contains \"Create ClientCertificate\"\n| where OperationName contains \"Compliance\" or OperationName contains \"DeviceHealthScript\" or OperationName contains \"RemediationScript\"\n| extend \n    ComplianceAction = case(\n        OperationName contains \"DeviceCompliancePolicy\", \"Policy Management\",\n        OperationName contains \"DeviceHealthScript\", \"Health Script\",\n        OperationName contains \"RemediationScript\", \"Remediation Script\",\n        OperationName contains \"Assignment\", \"Assignment Change\",\n        \"Other Compliance\"\n    ),\n    ActionType = case(\n        OperationName contains \"Create\", \"Created\",\n        OperationName contains \"Delete\", \"Deleted\",\n        OperationName contains \"Patch\", \"Modified\",\n        \"Other\"\n    )\n| summarize Count = count() by ComplianceAction, ActionType, TimeGenerated = bin(TimeGenerated, 1d)\n| order by TimeGenerated desc",
+                    "size": 0,
+                    "title": "📊 Compliance Activities Over Time",
+                    "queryType": 0,
+                    "resourceType": "microsoft.operationalinsights/workspaces",
+                    "visualization": "areachart",
+                    "chartSettings": {
+                      "xAxis": "TimeGenerated",
+                      "yAxis": [
+                        "Count"
+                      ],
+                      "group": "ComplianceAction"
+                    }
+                  },
+                  "customWidth": "50",
+                  "name": "ComplianceChart"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "IntuneAuditLogs\n| where TimeGenerated {AuditTimeRange}\n| extend ActorUPN = tostring(parse_json(Properties).Actor.UPN)\n| where '*' in ({ActorFilter}) or ActorUPN in ({ActorFilter})\n| where OperationName !contains \"Create ClientCertificate\"\n| where ResultType != \"Success\"\n| summarize FailedOperations = count() by OperationName, ResultType\n| order by FailedOperations desc\n| take 10",
+                    "size": 0,
+                    "title": "⚠️ Top Failed Operations",
+                    "queryType": 0,
+                    "resourceType": "microsoft.operationalinsights/workspaces",
+                    "visualization": "piechart"
+                  },
+                  "customWidth": "50",
+                  "name": "FailedOperationsChart"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "IntuneAuditLogs\n| where TimeGenerated {AuditTimeRange}\n| extend ActorUPN = tostring(parse_json(Properties).Actor.UPN)\n| where '*' in ({ActorFilter}) or ActorUPN in ({ActorFilter})\n| where OperationName !contains \"Create ClientCertificate\"\n| where OperationName contains \"Compliance\" or OperationName contains \"DeviceHealthScript\"\n| extend \n    ResourceName = tostring(parse_json(Properties).TargetDisplayNames[0]),\n    ComplianceType = case(\n        OperationName contains \"DeviceCompliancePolicy\", \"🛡️ Compliance Policy\",\n        OperationName contains \"DeviceHealthScript\", \"💊 Health Script\",\n        OperationName contains \"RemediationScript\", \"🔧 Remediation Script\",\n        \"📋 Other\"\n    ),\n    Action = case(\n        OperationName contains \"Create\", \"➕ Created\",\n        OperationName contains \"Delete\", \"❌ Deleted\",\n        OperationName contains \"Patch\", \"📝 Modified\",\n        \"🔄 Other\"\n    )\n| project \n    TimeGenerated,\n    ActorUPN,\n    ComplianceType,\n    Action,\n    ResourceName,\n    OperationName,\n    ResultType\n| order by TimeGenerated desc\n| take 50",
+                    "size": 0,
+                    "title": "📋 Recent Compliance Operations (Last 50)",
+                    "queryType": 0,
+                    "resourceType": "microsoft.operationalinsights/workspaces",
+                    "visualization": "table",
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "Action",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "icons",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "contains",
+                                "thresholdValue": "Created",
+                                "representation": "success",
+                                "text": "➕"
+                              },
+                              {
+                                "operator": "contains",
+                                "thresholdValue": "Deleted",
+                                "representation": "critical",
+                                "text": "❌"
+                              },
+                              {
+                                "operator": "contains",
+                                "thresholdValue": "Modified",
+                                "representation": "warning",
+                                "text": "📝"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "ResultType",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "colors",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Success",
+                                "representation": "green"
+                              },
+                              {
+                                "operator": "!=",
+                                "thresholdValue": "Success",
+                                "representation": "redBright"
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "customWidth": "100",
+                  "name": "ComplianceOperationsTable"
+                }
+              ]
+            },
+            "conditionalVisibility": {
+              "parameterName": "auditTab",
+              "comparison": "isEqualTo",
+              "value": "Compliance"
+            },
+            "name": "ComplianceTab"
+          },
+          {
+            "type": 12,
+            "content": {
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
+              "items": [
+                {
+                  "type": 1,
+                  "content": {
+                    "json": "### 🚨 Security Alerts & Monitoring\n\nReal-time alerting for critical security events, suspicious activities, and administrative actions requiring attention."
+                  },
+                  "name": "AlertsIntro"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "IntuneAuditLogs\n| where TimeGenerated {AuditTimeRange}\n| extend ActorUPN = tostring(parse_json(Properties).Actor.UPN)\n| where '*' in ({ActorFilter}) or ActorUPN in ({ActorFilter})\n| where OperationName !contains \"Create ClientCertificate\"\n| extend \n    AlertLevel = case(\n        OperationName contains \"Delete\" and (OperationName contains \"Policy\" or OperationName contains \"Configuration\"), \"🔴 Critical\",\n        ResultType != \"Success\" and OperationName contains \"Delete\", \"🟠 High\",\n        OperationName contains \"Assignment\" and ResultType != \"Success\", \"🟡 Medium\",\n        ResultType != \"Success\", \"🔵 Low\",\n        \"✅ Normal\"\n    ),\n    AlertCategory = case(\n        OperationName contains \"Delete\", \"Deletion Alert\",\n        ResultType != \"Success\", \"Failure Alert\", \n        OperationName contains \"Assignment\", \"Assignment Alert\",\n        \"Information\"\n    )\n| where AlertLevel != \"✅ Normal\"\n| summarize AlertCount = count() by AlertLevel, AlertCategory, TimeGenerated = bin(TimeGenerated, 1h)\n| order by TimeGenerated desc",
+                    "size": 0,
+                    "title": "🚨 Security Alerts Timeline",
+                    "queryType": 0,
+                    "resourceType": "microsoft.operationalinsights/workspaces",
+                    "visualization": "areachart",
+                    "chartSettings": {
+                      "xAxis": "TimeGenerated",
+                      "yAxis": [
+                        "AlertCount"
+                      ],
+                      "group": "AlertLevel"
+                    }
+                  },
+                  "customWidth": "60",
+                  "name": "AlertsChart"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "IntuneAuditLogs\n| where TimeGenerated {AuditTimeRange}\n| extend ActorUPN = tostring(parse_json(Properties).Actor.UPN)\n| where '*' in ({ActorFilter}) or ActorUPN in ({ActorFilter})\n| where OperationName !contains \"Create ClientCertificate\"\n| extend \n    AlertLevel = case(\n        OperationName contains \"Delete\" and (OperationName contains \"Policy\" or OperationName contains \"Configuration\"), \"Critical\",\n        ResultType != \"Success\" and OperationName contains \"Delete\", \"High\",\n        OperationName contains \"Assignment\" and ResultType != \"Success\", \"Medium\",\n        ResultType != \"Success\", \"Low\",\n        \"Normal\"\n    )\n| where AlertLevel != \"Normal\"\n| summarize Count = count() by AlertLevel\n| order by \n    case(\n        AlertLevel == \"Critical\", 1,\n        AlertLevel == \"High\", 2,\n        AlertLevel == \"Medium\", 3,\n        AlertLevel == \"Low\", 4,\n        5\n    )",
+                    "size": 3,
+                    "title": "🎯 Alert Summary",
+                    "queryType": 0,
+                    "resourceType": "microsoft.operationalinsights/workspaces",
+                    "visualization": "tiles",
+                    "tileSettings": {
+                      "titleContent": {
+                        "columnMatch": "AlertLevel",
+                        "formatter": 1
+                      },
+                      "leftContent": {
+                        "columnMatch": "Count",
+                        "formatter": 12,
+                        "formatOptions": {
+                          "palette": "auto"
+                        },
+                        "numberFormat": {
+                          "unit": 17,
+                          "options": {
+                            "style": "decimal",
+                            "maximumFractionDigits": 0
+                          }
+                        }
+                      },
+                      "secondaryContent": {
+                        "columnMatch": "AlertLevel",
+                        "formatter": 1
+                      },
+                      "showBorder": false
+                    }
+                  },
+                  "customWidth": "40",
+                  "name": "AlertSummaryTiles"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "IntuneAuditLogs\n| where TimeGenerated {AuditTimeRange}\n| extend ActorUPN = tostring(parse_json(Properties).Actor.UPN)\n| where '*' in ({ActorFilter}) or ActorUPN in ({ActorFilter})\n| where OperationName !contains \"Create ClientCertificate\"\n| extend \n    AlertLevel = case(\n        OperationName contains \"Delete\" and (OperationName contains \"Policy\" or OperationName contains \"Configuration\"), \"🔴 Critical\",\n        ResultType != \"Success\" and OperationName contains \"Delete\", \"🟠 High\",\n        OperationName contains \"Assignment\" and ResultType != \"Success\", \"🟡 Medium\",\n        ResultType != \"Success\", \"🔵 Low\",\n        \"✅ Normal\"\n    )\n| where AlertLevel != \"✅ Normal\"\n| extend \n    ResourceName = iif(isnotnull(parse_json(Properties).TargetDisplayNames) and array_length(parse_json(Properties).TargetDisplayNames) > 0, tostring(parse_json(Properties).TargetDisplayNames[0]), \"N/A\"),\n    AlertDescription = case(\n        OperationName contains \"Delete\" and (OperationName contains \"Policy\" or OperationName contains \"Configuration\"), strcat(\"Policy/Configuration deleted: \", ResourceName),\n        ResultType != \"Success\", strcat(\"Operation failed: \", OperationName, \" - \", ResultType),\n        strcat(\"Operation: \", OperationName)\n    )\n| project \n    TimeGenerated,\n    AlertLevel,\n    ActorUPN,\n    AlertDescription,\n    ResourceName,\n    OperationName,\n    ResultType,\n    CorrelationId\n| order by \n    case(\n        AlertLevel == \"🔴 Critical\", 1,\n        AlertLevel == \"🟠 High\", 2,\n        AlertLevel == \"🟡 Medium\", 3,\n        AlertLevel == \"🔵 Low\", 4,\n        5\n    ), TimeGenerated desc\n| take 100",
+                    "size": 0,
+                    "title": "🚨 Active Security Alerts (Last 100)",
+                    "queryType": 0,
+                    "resourceType": "microsoft.operationalinsights/workspaces",
+                    "visualization": "table",
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "AlertLevel",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "colors",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "contains",
+                                "thresholdValue": "Critical",
+                                "representation": "redBright"
+                              },
+                              {
+                                "operator": "contains",
+                                "thresholdValue": "High",
+                                "representation": "orange"
+                              },
+                              {
+                                "operator": "contains",
+                                "thresholdValue": "Medium",
+                                "representation": "yellow"
+                              },
+                              {
+                                "operator": "contains",
+                                "thresholdValue": "Low",
+                                "representation": "blue"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "ResultType",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "colors",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Success",
+                                "representation": "green"
+                              },
+                              {
+                                "operator": "!=",
+                                "thresholdValue": "Success",
+                                "representation": "redBright"
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "customWidth": "100",
+                  "name": "SecurityAlertsTable"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "IntuneAuditLogs\n| where TimeGenerated {AuditTimeRange}\n| extend ActorUPN = tostring(parse_json(Properties).Actor.UPN)\n| where '*' in ({ActorFilter}) or ActorUPN in ({ActorFilter})\n| where OperationName !contains \"Create ClientCertificate\"\n| extend BusinessHour = hourofday(TimeGenerated)\n| where BusinessHour < 6 or BusinessHour > 20  // Off-hours: before 6 AM or after 8 PM\n| extend \n    RiskLevel = case(\n        OperationName contains \"Delete\", \"High Risk\",\n        OperationName contains \"Create\" or OperationName contains \"Patch\", \"Medium Risk\",\n        \"Low Risk\"\n    )\n| summarize \n    OffHoursCount = count(),\n    UniqueUsers = dcount(ActorUPN),\n    Operations = make_set(OperationName, 5)\n by ActorUPN, RiskLevel, TimeGenerated = bin(TimeGenerated, 1d)\n| order by OffHoursCount desc, TimeGenerated desc\n| take 20",
+                    "size": 0,
+                    "title": "🌙 Off-Hours Activity Monitoring",
+                    "queryType": 0,
+                    "resourceType": "microsoft.operationalinsights/workspaces",
+                    "visualization": "table",
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "RiskLevel",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "colors",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "contains",
+                                "thresholdValue": "High",
+                                "representation": "redBright"
+                              },
+                              {
+                                "operator": "contains",
+                                "thresholdValue": "Medium",
+                                "representation": "yellow"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "representation": "green"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "OffHoursCount",
+                          "formatter": 8,
+                          "formatOptions": {
+                            "palette": "redBright"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "customWidth": "100",
+                  "name": "OffHoursActivityTable"
+                }
+              ]
+            },
+            "conditionalVisibility": {
+              "parameterName": "auditTab",
+              "comparison": "isEqualTo",
+              "value": "Alerts"
+            },
+            "name": "AlertsTab"
           }
         ]
       },
@@ -9163,10 +10059,361 @@
         "value": "Audit"
       },
       "name": "AuditGroup"
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "title": "Browser Extensions",
+        "items": [
+          {
+            "type": 1,
+            "content": {
+              "json": "### 🌐 Browser Extensions Inventory\n\nThis dashboard provides comprehensive monitoring of browser extensions across your managed devices. Data is collected from Chrome, Edge, and Firefox browsers using the PowerShell script that uploads extension information to the `DevicesBrowserExtensionsInventory_CL` table.\n\n**Data Collection Scope:**\n- **Chrome** and **Microsoft Edge** extensions from user profiles\n- **Firefox** add-ons from user profiles\n- Extension details including name, version, and installation status\n- User and device association information"
+            },
+            "name": "ExtensionsIntro"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "DevicesBrowserExtensionsInventory_CL\n| summarize DeviceCount = dcount(DeviceName_s), ExtensionCount = dcount(ExtensionID_s), TotalInstallations = count() by TimeGenerated_t = bin(TimeGenerated, 1d)\n| order by TimeGenerated_t desc\n| take 1\n| project DeviceCount, ExtensionCount, TotalInstallations",
+              "size": 4,
+              "title": "Extension Statistics Overview",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "tiles",
+              "tileSettings": {
+                "titleContent": {
+                  "columnMatch": "DeviceCount",
+                  "formatter": 1,
+                  "formatOptions": {
+                    "customDisplayName": "Devices with Extensions"
+                  }
+                },
+                "leftContent": {
+                  "columnMatch": "DeviceCount",
+                  "formatter": 12,
+                  "formatOptions": {
+                    "palette": "blue"
+                  },
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "style": "decimal",
+                      "useGrouping": false,
+                      "maximumFractionDigits": 2,
+                      "maximumSignificantDigits": 3
+                    }
+                  }
+                },
+                "secondaryContent": {
+                  "columnMatch": "ExtensionCount",
+                  "formatter": 1,
+                  "formatOptions": {
+                    "customDisplayName": "Unique Extensions"
+                  }
+                },
+                "showBorder": false
+              }
+            },
+            "customWidth": "33",
+            "name": "ExtensionStats1"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "DevicesBrowserExtensionsInventory_CL\n| summarize DeviceCount = dcount(DeviceName_s), ExtensionCount = dcount(ExtensionID_s), TotalInstallations = count() by TimeGenerated_t = bin(TimeGenerated, 1d)\n| order by TimeGenerated_t desc\n| take 1\n| project DeviceCount, ExtensionCount, TotalInstallations",
+              "size": 4,
+              "title": "Extension Statistics Overview",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "tiles",
+              "tileSettings": {
+                "titleContent": {
+                  "columnMatch": "ExtensionCount",
+                  "formatter": 1,
+                  "formatOptions": {
+                    "customDisplayName": "Unique Extensions"
+                  }
+                },
+                "leftContent": {
+                  "columnMatch": "ExtensionCount",
+                  "formatter": 12,
+                  "formatOptions": {
+                    "palette": "green"
+                  },
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "style": "decimal",
+                      "useGrouping": false,
+                      "maximumFractionDigits": 2,
+                      "maximumSignificantDigits": 3
+                    }
+                  }
+                },
+                "secondaryContent": {
+                  "columnMatch": "TotalInstallations",
+                  "formatter": 1,
+                  "formatOptions": {
+                    "customDisplayName": "Total Installations"
+                  }
+                },
+                "showBorder": false
+              }
+            },
+            "customWidth": "33",
+            "name": "ExtensionStats2"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "DevicesBrowserExtensionsInventory_CL\n| summarize DeviceCount = dcount(DeviceName_s), ExtensionCount = dcount(ExtensionID_s), TotalInstallations = count() by TimeGenerated_t = bin(TimeGenerated, 1d)\n| order by TimeGenerated_t desc\n| take 1\n| project DeviceCount, ExtensionCount, TotalInstallations",
+              "size": 4,
+              "title": "Extension Statistics Overview",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "tiles",
+              "tileSettings": {
+                "titleContent": {
+                  "columnMatch": "TotalInstallations",
+                  "formatter": 1,
+                  "formatOptions": {
+                    "customDisplayName": "Total Installations"
+                  }
+                },
+                "leftContent": {
+                  "columnMatch": "TotalInstallations",
+                  "formatter": 12,
+                  "formatOptions": {
+                    "palette": "orange"
+                  },
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "style": "decimal",
+                      "useGrouping": false,
+                      "maximumFractionDigits": 2,
+                      "maximumSignificantDigits": 3
+                    }
+                  }
+                },
+                "showBorder": false
+              }
+            },
+            "customWidth": "33",
+            "name": "ExtensionStats3"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "DevicesBrowserExtensionsInventory_CL\n| summarize InstallCount = count() by Browser_s\n| order by InstallCount desc",
+              "size": 1,
+              "title": "Extensions by Browser",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "piechart",
+              "chartSettings": {
+                "showLegend": true,
+                "showDataLabels": true
+              }
+            },
+            "customWidth": "50",
+            "name": "ExtensionsByBrowser"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "DevicesBrowserExtensionsInventory_CL\n| summarize InstallCount = count() by ExtensionName_s\n| top 10 by InstallCount desc\n| order by InstallCount desc",
+              "size": 1,
+              "title": "Top 10 Most Installed Extensions",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "barchart",
+              "chartSettings": {
+                "xAxis": "ExtensionName_s",
+                "yAxis": [
+                  "InstallCount"
+                ],
+                "showDataLabels": true,
+                "ySettings": {
+                  "isLogarithmic": false,
+                  "min": 0
+                }
+              }
+            },
+            "customWidth": "50",
+            "name": "TopExtensions"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "DevicesBrowserExtensionsInventory_CL\n| summarize DevicesWithExtensions = dcount(DeviceName_s) by d = bin(TimeGenerated, 1d)\n| order by d desc\n| take 30\n| render timechart",
+              "size": 0,
+              "title": "Device Extension Activity Trend (Last 30 Days)",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "linechart"
+            },
+            "name": "ExtensionTrend"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "DevicesBrowserExtensionsInventory_CL\n| where TimeGenerated >= ago(7d)\n| summarize \n    Devices = dcount(DeviceName_s),\n    UniqueExtensions = dcount(ExtensionID_s),\n    TotalInstallations = count(),\n    LastSeen = max(TimeGenerated)\n    by ExtensionName_s, Browser_s\n| order by TotalInstallations desc\n| project \n    ['Extension Name'] = ExtensionName_s,\n    Browser = Browser_s,\n    ['Devices'] = Devices,\n    ['Installations'] = TotalInstallations,\n    ['Last Seen'] = LastSeen",
+              "size": 0,
+              "title": "Detailed Extension Inventory (Last 7 Days)",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "table",
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "Devices",
+                    "formatter": 4,
+                    "formatOptions": {
+                      "palette": "blue"
+                    }
+                  },
+                  {
+                    "columnMatch": "Installations",
+                    "formatter": 4,
+                    "formatOptions": {
+                      "palette": "green"
+                    }
+                  },
+                  {
+                    "columnMatch": "Last Seen",
+                    "formatter": 6
+                  }
+                ],
+                "filter": true
+              },
+              "sortBy": []
+            },
+            "name": "DetailedExtensionInventory"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "DevicesBrowserExtensionsInventory_CL\n| where TimeGenerated >= ago(7d)\n| summarize \n    Extensions = dcount(ExtensionID_s),\n    TotalInstallations = count(),\n    LastActivity = max(TimeGenerated),\n    Browsers = make_set(Browser_s)\n    by DeviceName_s, Username_s\n| order by Extensions desc\n| project \n    ['Device Name'] = DeviceName_s,\n    ['Username'] = Username_s,\n    ['Extensions'] = Extensions,\n    ['Total Installations'] = TotalInstallations,\n    ['Browsers'] = Browsers,\n    ['Last Activity'] = LastActivity",
+              "size": 0,
+              "title": "Extensions by Device and User (Last 7 Days)",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "table",
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "Extensions",
+                    "formatter": 4,
+                    "formatOptions": {
+                      "palette": "blue"
+                    }
+                  },
+                  {
+                    "columnMatch": "Total Installations",
+                    "formatter": 4,
+                    "formatOptions": {
+                      "palette": "green"
+                    }
+                  },
+                  {
+                    "columnMatch": "Last Activity",
+                    "formatter": 6
+                  }
+                ],
+                "filter": true
+              },
+              "sortBy": []
+            },
+            "name": "ExtensionsByDevice"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "DevicesBrowserExtensionsInventory_CL\n| where TimeGenerated >= ago(7d)\n| extend SecurityCategory = case(\n    ExtensionName_s has \"ublock\" or ExtensionName_s has \"adblock\" or ExtensionName_s has \"adguard\", \"Ad Blocker\",\n    ExtensionName_s has \"lastpass\" or ExtensionName_s has \"1password\" or ExtensionName_s has \"bitwarden\" or ExtensionName_s has \"dashlane\", \"Password Manager\",\n    ExtensionName_s has \"antivirus\" or ExtensionName_s has \"security\" or ExtensionName_s has \"malware\", \"Security\",\n    ExtensionName_s has \"vpn\" or ExtensionName_s has \"proxy\", \"VPN/Proxy\",\n    ExtensionName_s has \"downloader\" or ExtensionName_s has \"torrent\", \"Downloader\",\n    \"Other\"\n)\n| summarize Count = count(), Devices = dcount(DeviceName_s) by SecurityCategory\n| order by Count desc",
+              "size": 1,
+              "title": "Extensions by Security Category",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "table",
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "Count",
+                    "formatter": 4,
+                    "formatOptions": {
+                      "palette": "blue"
+                    }
+                  },
+                  {
+                    "columnMatch": "Devices",
+                    "formatter": 4,
+                    "formatOptions": {
+                      "palette": "green"
+                    }
+                  }
+                ]
+              }
+            },
+            "customWidth": "50",
+            "name": "SecurityCategories"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "DevicesBrowserExtensionsInventory_CL\n| where TimeGenerated >= ago(30d)\n| extend DaysOld = datetime_diff('day', now(), TimeGenerated)\n| summarize \n    UniqueExtensions = dcount(ExtensionID_s),\n    TotalInstallations = count()\n    by AgeGroup = case(\n        DaysOld <= 1, 'Last 24 hours',\n        DaysOld <= 7, 'Last week',\n        DaysOld <= 30, 'Last month',\n        'Older'\n    )\n| extend SortOrder = case(\n        AgeGroup == 'Last 24 hours', 1,\n        AgeGroup == 'Last week', 2,\n        AgeGroup == 'Last month', 3,\n        4\n    )\n| order by SortOrder asc\n| project-away SortOrder",
+              "size": 1,
+              "title": "Extension Data Freshness",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "table",
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "UniqueExtensions",
+                    "formatter": 4,
+                    "formatOptions": {
+                      "palette": "blue"
+                    }
+                  },
+                  {
+                    "columnMatch": "TotalInstallations",
+                    "formatter": 4,
+                    "formatOptions": {
+                      "palette": "green"
+                    }
+                  }
+                ]
+              }
+            },
+            "customWidth": "50",
+            "name": "DataFreshness"
+          }
+        ]
+      },
+      "conditionalVisibility": {
+        "parameterName": "tab",
+        "comparison": "isEqualTo",
+        "value": "BrowserExtensions"
+      },
+      "name": "BrowserExtensionsGroup"
     }
   ],
   "fallbackResourceIds": [
-    "Azure Monitor"
+    "/subscriptions/3f66ecfd-c011-4956-bcea-d431a322eb15/resourceGroups/csg-audit/providers/Microsoft.OperationalInsights/workspaces/csg-auditlogs"
   ],
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
 }


### PR DESCRIPTION
Added Audit notebook dashboard and Browser extension tab.

I don't know if it will be usable, but I added a script (run via Detection Script in Scripts and Remediations) that collects browser extension data into LogAnalytics. (by Manuel Jong - https://github.com/ManuelJong/Public/blob/main/Collect-BrowserExtensions).